### PR TITLE
Allow the location of the /admin directory to be specified in settings

### DIFF
--- a/cookieless/example_settings.py
+++ b/cookieless/example_settings.py
@@ -31,6 +31,10 @@ COOKIELESS['URL_SPECIFIC'] = True
 # Delete any cookies found when on a no_cookies URL  
 COOKIELESS['DELETE_COOKIES']
 
+# Specify what directory should be excluded from being cookieless
+# Most common setting is to exclude your admin directory 
+COOKIELESS['EXCLUDE_DIR'] = '/admin'
+
 #############################
 
 # Settings to be used when running unit tests

--- a/cookieless/middleware.py
+++ b/cookieless/middleware.py
@@ -153,7 +153,8 @@ class CookielessSessionMiddleware(object):
         """ Option to rewrite forms and urls to add session automatically """
         name = settings.SESSION_COOKIE_NAME
         session_key = ''
-        if request.session.session_key and not request.path.startswith("/admin"):  
+        if request.session.session_key and \
+           not request.path.startswith(self.settings.get('EXCLUDE_DIR', '/admin')):  
             session_key = self._sesh.encrypt(request, request.session.session_key) 
 
             if self.settings.get('USE_GET', False) and session_key:


### PR DESCRIPTION
Update to specify a directory to be excluded from cookieless in the settings. This allows Django apps that don't have the admin area off /admin (as the code currently uses) to specify where the admin area is.