### PR TITLE
Fixes template directory running for unit tests

### DIFF
--- a/cookieless/tests/settings.py
+++ b/cookieless/tests/settings.py
@@ -57,7 +57,7 @@ ROOT_URLCONF = "cookieless.tests.urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": ["django-cookieless/cookieless/tests/templates"],
+        "DIRS": [BASE_DIR+"/tests/templates"],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [


### PR DESCRIPTION
It was mentioned in #4 that the unit tests didn't run.

Changing this to use BASE_DIR allowed the tests with
`django-admin test cookieless.tests --settings=cookieless.tests.settings`

To run from anywhere, as stated in the README. 

```
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
..............
----------------------------------------------------------------------
Ran 14 tests in 0.220s

OK
Destroying test database for alias 'default'...
```